### PR TITLE
Tabs

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1 viewport-fit=cover" />
     <meta name="color-scheme" content="dark light" />
     <link rel="stylesheet" href="/shared.css" />
-    <link rel="stylesheet" href="/theme_light.css" id="themeLinkElement" />
+    <link rel="stylesheet" href="/theme_charcoal.css" id="themeLinkElement" />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/mdbassit/Coloris@latest/dist/coloris.min.css"/>
     <script src="https://cdn.jsdelivr.net/gh/mdbassit/Coloris@latest/dist/coloris.min.js"></script>
     %sveltekit.head%
@@ -16,7 +16,7 @@
 
 <script>
     let theme = window.localStorage.getItem('theme');
-    setTheme(theme ?? "light");
+    setTheme(theme ?? "charcoal");
     fetch("/themes.json").then((res) => res.json()).then(allowedThemes => {
         if (Object.keys(allowedThemes).indexOf(theme) === -1) {
             theme = Object.keys(allowedThemes)[0];

--- a/src/lib/components/ContextMenu.svelte
+++ b/src/lib/components/ContextMenu.svelte
@@ -76,7 +76,7 @@
     <div
             role="presentation"
             onclick={() => visible = false}
-            style="position: fixed; left: 0; top: 0; width: 100vw; height: 100vh; overflow: hidden;"
+            style="position: fixed; left: 0; top: 0; width: 100vw; height: 100vh; overflow: auto;"
             oncontextmenu={e => {
                 visible = false;
                 e.preventDefault();

--- a/src/lib/components/DropDown.svelte
+++ b/src/lib/components/DropDown.svelte
@@ -21,11 +21,10 @@
     let containerElement: HTMLDivElement | null = $state(null);
 
     function clickOutside(event: MouseEvent) {
-        // Solo cerrar si el click fue realmente fuera del contenedor
         const target = event.target as Node;
         if (containerElement && !containerElement.contains(target)) {
             optionsVisible = false;
-            // Reset to selected value if no selection was made
+
             if (selectedOption) {
                 value = selectedOption.text;
             }
@@ -43,10 +42,8 @@
     let selectedOption = $derived(options?.find(o => o?.selected));
     let value = $state("");
 
-    // Sincronizar value cuando selectedOption cambia (para evitar el warning de Svelte)
     $effect(() => {
         if (!optionsVisible) {
-            // Solo actualizar si la dropdown no está visible (es decir, el usuario no está filtrando)
             value = selectedOption?.text ?? "";
         }
     });

--- a/src/lib/components/DropDown.svelte
+++ b/src/lib/components/DropDown.svelte
@@ -11,17 +11,25 @@
         id: string,
         options: {
             text: string,
-            name: string,
+            name: string | null,
             selected: boolean
         }[],
-        oninput: (name: string) => void
+        oninput: (name: string | null) => void
     } = $props();
 
     let optionsVisible = $state(false);
+    let containerElement: HTMLDivElement | null = $state(null);
 
-    function clickOutside() {
-        optionsVisible = false;
-        value = selectedOption.text;
+    function clickOutside(event: MouseEvent) {
+        // Solo cerrar si el click fue realmente fuera del contenedor
+        const target = event.target as Node;
+        if (containerElement && !containerElement.contains(target)) {
+            optionsVisible = false;
+            // Reset to selected value if no selection was made
+            if (selectedOption) {
+                value = selectedOption.text;
+            }
+        }
     }
 
     onMount(() => {
@@ -32,52 +40,72 @@
         }
     });
 
-    let selectedOption = $derived(options.find(o => o.selected));
-    let value = $derived(selectedOption?.text ?? "");
+    let selectedOption = $derived(options?.find(o => o?.selected));
+    let value = $state("");
+
+    // Sincronizar value cuando selectedOption cambia (para evitar el warning de Svelte)
+    $effect(() => {
+        if (!optionsVisible) {
+            // Solo actualizar si la dropdown no está visible (es decir, el usuario no está filtrando)
+            value = selectedOption?.text ?? "";
+        }
+    });
 
     function filter() {
-        if (value == "" || selectedOption?.text?.toLowerCase() == value.toLowerCase()) {
+        if (!options || !Array.isArray(options)) {
+            return [];
+        }
+        if (value === "" || selectedOption?.text?.toLowerCase() === value.toLowerCase()) {
             return options;
         }
-        return options.filter(v => v.text.toLowerCase().includes(value.toLowerCase()) || v.name.toLowerCase().includes(value.toLowerCase()));
+        return options.filter(v => {
+            if (!v) return false;
+            const textMatch = v.text?.toLowerCase().includes(value.toLowerCase()) || false;
+            const nameMatch = v.name?.toString().toLowerCase().includes(value.toLowerCase()) || false;
+            return textMatch || nameMatch;
+        });
     }
 
     let visibleOptions = $derived.by(filter);
 
-    function clickedOption(option) {
+    function clickedOption(option: any) {
         optionsVisible = false;
-        value = option.text;
-        oninput(option.name);
+        if (option && option.text) {
+            value = option.text;
+            oninput(option.name ?? "");
+        }
     }
 </script>
 
-<input
-        name={name}
-        id={id}
-        onclick={e => {
-            e.stopPropagation();
-            optionsVisible = true;
-        }}
-        bind:value={value}
-/>
+<div bind:this={containerElement}>
+    <input
+            name={name}
+            id={id}
+            onclick={e => {
+                e.stopPropagation();
+                optionsVisible = true;
+            }}
+            bind:value={value}
+    />
 
-{#if optionsVisible}
-    <div class="input-like" style="display: flex; flex-direction: column; max-height: 250px; overflow-y: scroll; padding: 7px 0 0 0;">
-        {#each visibleOptions as visibleOption, index}
-            <div
-                    style="color: var(--text); padding: 7px 10px; cursor: pointer; border-bottom: 1px solid var(--text);"
-                    role="option"
-                    tabindex={index}
-                    aria-selected={visibleOption.selected}
-                    onclick={() => {
-                        clickedOption(visibleOption);
-                    }}
-                    onkeydown={e => {
-                        if (e.key === "Enter" || e.key === "Space") {
+    {#if optionsVisible}
+        <div class="input-like" style="display: flex; flex-direction: column; max-height: 250px; overflow-y: scroll; padding: 7px 0 0 0;">
+            {#each visibleOptions as visibleOption, index}
+                <div
+                        style="color: var(--text); padding: 7px 10px; cursor: pointer; border-bottom: 1px solid var(--text);"
+                        role="option"
+                        tabindex={index}
+                        aria-selected={visibleOption.selected}
+                        onclick={() => {
                             clickedOption(visibleOption);
-                        }
-                    }}
-            >{visibleOption.text}</div>
-        {/each}
-    </div>
-{/if}
+                        }}
+                        onkeydown={e => {
+                            if (e.key === "Enter" || e.key === "Space") {
+                                clickedOption(visibleOption);
+                            }
+                        }}
+                >{visibleOption.text}</div>
+            {/each}
+        </div>
+    {/if}
+</div>

--- a/src/lib/components/editor/ChestMenu.svelte
+++ b/src/lib/components/editor/ChestMenu.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
-    import {Argument, BlockTagItem, Codeblock, Item, ITEM_TYPES, Template} from "$lib/diamondfire";
+    import { Argument, BlockTagItem, Codeblock, Item, ITEM_TYPES, Template } from "$lib/diamondfire";
     import MiniMessageRenderer from "$lib/components/MiniMessageRenderer.svelte";
-    import {range} from "$lib/utils";
-    import {startObfuscateText, stopObfuscatedText} from "$lib/minimessage";
-    import {getContext, onDestroy, onMount} from "svelte";
-    import {secondLine} from "$lib/df_reprs";
-    import {type InspectorObject, isSpecialCase} from "$lib/components/editor/Inspector.svelte";
+    import { range } from "$lib/utils";
+    import { startObfuscateText, stopObfuscatedText } from "$lib/minimessage";
+    import { getContext, onDestroy, onMount } from "svelte";
+    import { secondLine } from "$lib/df_reprs";
+    import type { InspectorObject } from "$lib/components/editor/editor-state";
     import ChestMenuItem from "$lib/components/editor/ChestMenuItem.svelte";
 
     let {
@@ -17,17 +17,19 @@
         dismiss: dismissPassed,
         setInspectorObjects,
         updateTemplateJSON,
-        visible = false
+        visible = false,
+        inspectorSpecialCase = false
     }: {
         blockIndex: number,
         templateObject: Template,
         inspectingItem: number,
         freezeInDepthView: boolean,
-        inspectingItemItem: Item,
+        inspectingItemItem: Item | null,
         dismiss: () => void,
         setInspectorObjects: (iO: InspectorObject[][] | null) => void,
         updateTemplateJSON: () => void,
-        visible: boolean
+        visible: boolean,
+        inspectorSpecialCase: boolean
     } = $props();
 
     let block: Codeblock = $derived(templateObject.blocks[blockIndex]);
@@ -38,6 +40,7 @@
     let spanColor: string | null = $state(null);
     let ttDirect = $state(false);
     let tooltipElement: HTMLElement | null = $state(null);
+    let chestMenuElement: HTMLDivElement | null = $state(null);
 
     let actions = getContext("actiondump").actiondump.actions;
     let actionCategoryMap = getContext("actiondump").actiondump.actions_category_reverse_map;
@@ -50,10 +53,9 @@
     }
 
     function pointerMove(event: PointerEvent) {
-        let chestMenu = document.getElementById("chestmenu");
-        if (tooltip !== null) {
+        if (tooltip !== null && chestMenuElement !== null && tooltipElement !== null) {
             tooltipX = event.clientX + 5;
-            let openLeft = (event.clientX - chestMenu.offsetLeft) > chestMenu.offsetWidth / 2;
+            let openLeft = (event.clientX - chestMenuElement.offsetLeft) > chestMenuElement.offsetWidth / 2;
             if (openLeft) {
                 tooltipX = event.clientX - tooltipElement.offsetWidth - 5;
             }
@@ -74,15 +76,15 @@
         }
     }
 
-    let chestItems: (null | Argument)[] = $state(range(0, 27).map(_ => null));
+    let chestItems: (null | Argument)[] = $state(range(0, 27).map(() => null));
 
     function updateChestItems() {
         if (!block || block.isBracket()) {
-            chestItems = range(0, 27).map(_ => null);
+            chestItems = range(0, 27).map(() => null);
             return;
         }
         let contents = block.args;
-        chestItems = range(0, 27).map(_ => null);
+        chestItems = range(0, 27).map(() => null);
         for (let arg of contents) {
             if (arg.slot > 27) continue;
             chestItems[arg.slot] = arg;
@@ -114,7 +116,7 @@
             style="width: 100%; height: 100%; background: rgba(0, 0, 0, 0.25); position: absolute; top: 0px; left: 0px; cursor: pointer;"
             onclick={dismiss}
     >
-        <div role="presentation" class="container" id="chestmenu" onclick={e => {
+        <div role="presentation" class="container chestmenu" bind:this={chestMenuElement} onclick={e => {
             setInspectorObjects(null);
             freezeInDepthView = false;
             e.stopPropagation();
@@ -132,7 +134,7 @@
                             chestItems[index] = null;
                             chestItems = chestItems;
                             setInspectorObjects(null);
-                            inspectingItem = null;
+                            inspectingItem = -1;
                             freezeInDepthView = false;
                             block.args.splice(getItemIndex(index), 1);
                             updateChestItems();
@@ -165,7 +167,7 @@
                             inspectingItem = getItemIndex(index);
                             inspectingItemItem = block.args[inspectingItem].item;
                         }}
-                        doInspect={() => (!freezeInDepthView || getItemIndex(index) === inspectingItem) && !isSpecialCase()}
+                        doInspect={() => (!freezeInDepthView || getItemIndex(index) === inspectingItem) && !inspectorSpecialCase}
                         innerItem={item ? item.item : null}
                         nullItemBehavior={() => setInspectorObjects(null)}
                         allowedItemsList={blTags.find(v => v.slot === index) ? ITEM_TYPES : ITEM_TYPES.toSpliced(ITEM_TYPES.indexOf("bl_tag"), 1)}
@@ -202,7 +204,7 @@
         color: var(--text-cool);
     }
 
-    #chestmenu {
+    .chestmenu {
         display: grid;
         grid-template-columns: 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr;
         grid-template-rows: 40px 1fr 1fr 1fr;

--- a/src/lib/components/editor/ChestMenuItem.svelte
+++ b/src/lib/components/editor/ChestMenuItem.svelte
@@ -2,7 +2,7 @@
     import Item from "$lib/components/editor/Item.svelte";
     import {itemDefaultValue} from "$lib/diamondfire";
     import {TYPE_DISPLAY_MAP} from "$lib/df_reprs";
-    import type {InspectorObject} from "$lib/components/editor/Inspector.svelte";
+    import type {InspectorObject} from "$lib/components/editor/editor-state";
     import {setContextMenu} from "$lib/components/ContextMenu.svelte";
     import {getContext} from "svelte";
 

--- a/src/lib/components/editor/CodeRenderer.svelte
+++ b/src/lib/components/editor/CodeRenderer.svelte
@@ -43,6 +43,8 @@
     }));
 
     let divElement: HTMLDivElement | null = $state(null);
+    let canvasElement: HTMLCanvasElement | null = $state(null);
+    let webGLRenderer: WebGLRenderer | null = $state(null);
     let maxX = $state(0);
 
     $effect(() => {
@@ -52,6 +54,27 @@
         if (rendererState.cameraZoomTarget !== cameraZoom.target) {
             cameraZoom.target = rendererState.cameraZoomTarget;
         }
+    });
+
+    // Cleanup WebGL context on component unmount
+    $effect(() => {
+        return () => {
+            if (webGLRenderer) {
+                webGLRenderer.dispose();
+                webGLRenderer = null;
+            }
+            if (canvasElement) {
+                // Clear canvas and release WebGL context
+                const gl = canvasElement.getContext('webgl2') || canvasElement.getContext('webgl');
+                if (gl) {
+                    const ext = gl.getExtension('WEBGL_lose_context');
+                    if (ext) {
+                        ext.loseContext();
+                    }
+                }
+                canvasElement = null;
+            }
+        };
     });
 
     let lastTouchPosition: [number, number] = $state([0, 0]);
@@ -95,15 +118,17 @@
     clearInspector();
 }} role="presentation" bind:this={divElement}>
     <Canvas createRenderer={(canvas: HTMLCanvasElement) => {
+        canvasElement = canvas;
         canvas.addEventListener("touchstart", touchStart);
         canvas.addEventListener("touchmove", touchMove);
-        return new WebGLRenderer({
+        webGLRenderer = new WebGLRenderer({
             canvas,
             preserveDrawingBuffer: true,
             alpha: true,
             antialias: true,
             powerPreference: 'high-performance'
         });
+        return webGLRenderer;
     }}>
         <CodeRendererInside
                 bind:editBlockIndex

--- a/src/lib/components/editor/CodeRenderer.svelte
+++ b/src/lib/components/editor/CodeRenderer.svelte
@@ -1,13 +1,31 @@
 <script lang="ts">
     import { Canvas } from "@threlte/core";
+    import type { Template } from "$lib/diamondfire";
     import CodeRendererInside from "$lib/components/editor/CodeRendererInside.svelte";
-    import { setInspectorObjects } from "$lib/components/editor/Inspector.svelte";
+    import type { EditorRendererState, InspectorObject } from "$lib/components/editor/editor-state";
     import { Tween } from "svelte/motion";
     import { cubicOut } from "svelte/easing";
     import { WebGLRenderer } from "three";
 
-    let { template, clickChest, editBlockIndex = $bindable(), updateTemplateJSON } = $props();
-    let cameraX = new Tween(0, {
+    let {
+        template,
+        clickChest,
+        editBlockIndex = $bindable(),
+        updateTemplateJSON,
+        clearInspector,
+        setInspectorObjects,
+        rendererState = $bindable()
+    }: {
+        template: Template,
+        clickChest: (index: number) => void,
+        editBlockIndex: number,
+        updateTemplateJSON: () => void,
+        clearInspector: () => void,
+        setInspectorObjects: (iO: InspectorObject[][] | null) => void,
+        rendererState: EditorRendererState
+    } = $props();
+
+    let cameraX = new Tween(rendererState.cameraXTarget, {
         duration: 500,
         easing: cubicOut
     });
@@ -19,13 +37,22 @@
         duration: 500,
         easing: cubicOut
     }));
-    let cameraZoom = $state(new Tween(0, {
+    let cameraZoom = $state(new Tween(rendererState.cameraZoomTarget, {
         duration: 500,
         easing: cubicOut
     }));
 
-    let divElement = $state(null);
+    let divElement: HTMLDivElement | null = $state(null);
     let maxX = $state(0);
+
+    $effect(() => {
+        if (rendererState.cameraXTarget !== cameraX.target) {
+            cameraX.target = rendererState.cameraXTarget;
+        }
+        if (rendererState.cameraZoomTarget !== cameraZoom.target) {
+            cameraZoom.target = rendererState.cameraZoomTarget;
+        }
+    });
 
     let lastTouchPosition: [number, number] = $state([0, 0]);
     function touchStart(event: TouchEvent) {
@@ -37,6 +64,10 @@
         let delta = [touch.clientX - lastTouchPosition[0], touch.clientY - lastTouchPosition[1]];
         lastTouchPosition = [touch.clientX, touch.clientY];
         cameraX.target -= delta[0] * 0.02;
+        rendererState = {
+            ...rendererState,
+            cameraXTarget: cameraX.target
+        };
     }
 </script>
 
@@ -47,13 +78,21 @@
     }
     if (ev.ctrlKey) {
         cameraZoom.target += dy;
+        rendererState = {
+            ...rendererState,
+            cameraZoomTarget: cameraZoom.target
+        };
     } else {
         cameraX.target = Math.max(Math.min(cameraX.target + dy, maxX), -2);
+        rendererState = {
+            ...rendererState,
+            cameraXTarget: cameraX.target
+        };
     }
     ev.preventDefault();
 }} style="height: 100%" onclick={() => {
     editBlockIndex = -1;
-    setInspectorObjects(null);
+    clearInspector();
 }} role="presentation" bind:this={divElement}>
     <Canvas createRenderer={(canvas: HTMLCanvasElement) => {
         canvas.addEventListener("touchstart", touchStart);
@@ -69,6 +108,7 @@
         <CodeRendererInside
                 bind:editBlockIndex
                 bind:maxX
+                bind:rendererState
                 {template}
                 {cameraX}
                 {cameraY}
@@ -76,6 +116,7 @@
                 {cameraZoom}
                 {clickChest}
                 {divElement}
+                {setInspectorObjects}
                 {updateTemplateJSON}
         ></CodeRendererInside>
     </Canvas>

--- a/src/lib/components/editor/CodeRenderer.svelte
+++ b/src/lib/components/editor/CodeRenderer.svelte
@@ -113,7 +113,7 @@
         };
     }
     ev.preventDefault();
-}} style="height: 100%" onclick={() => {
+}} style="height: 100%; min-height: 0; min-width: 0;" onclick={() => {
     editBlockIndex = -1;
     clearInspector();
 }} role="presentation" bind:this={divElement}>

--- a/src/lib/components/editor/CodeRendererInside.svelte
+++ b/src/lib/components/editor/CodeRendererInside.svelte
@@ -2,6 +2,7 @@
     import {
         Codeblock,
         Bracket,
+        Block,
         BLOCK_CATEGORIES,
         Template,
         CATEGORY_ATTRIBUTES,
@@ -9,8 +10,8 @@
         CATEGORY_BRACKETS_MAP, Argument
     } from "$lib/diamondfire";
     import { firstLine, secondLine, thirdLine, fourthLine, CATEGORY_MAP } from '$lib/df_reprs';
-    import { setInspectorObjects } from "$lib/components/editor/Inspector.svelte";
     import { ENTITY_SELECTION_TARGET_DROPDOWN, PLAYER_SELECTION_TARGET_DROPDOWN } from "$lib/components/editor/Item.svelte";
+    import type { EditorRendererState, InspectorObject } from "$lib/components/editor/editor-state";
     import {T, useThrelte} from "@threlte/core";
     import { useTexture, useGltf, Text } from "@threlte/extras";
     import { interactivity } from '@threlte/extras';
@@ -36,6 +37,8 @@
         clickChest,
         editBlockIndex = $bindable(),
         divElement,
+        rendererState = $bindable(),
+        setInspectorObjects,
         updateTemplateJSON
     }: {
         template: Template,
@@ -46,7 +49,9 @@
         cameraZoom: Tween<number>,
         clickChest: (index: number) => void,
         editBlockIndex: number,
-        divElement: HTMLDivElement,
+        divElement: HTMLDivElement | null,
+        rendererState: EditorRendererState,
+        setInspectorObjects: (iO: InspectorObject[][] | null) => void,
         updateTemplateJSON: () => void
     } = $props();
 
@@ -66,7 +71,12 @@
     }
 
     onMount(() => {
-        divElement.addEventListener("contextmenu", event => {
+        const targetElement = divElement;
+        if (targetElement === null) {
+            return;
+        }
+
+        const handleContextMenu = (event: PointerEvent) => {
             event.preventDefault();
             setContextMenu(event, [
                 {
@@ -90,13 +100,20 @@
                     callback: () => {
                         template.blocks = [];
                         selection = [];
+                        startSelection = null;
                         movingSelection = false;
                         updateTemplateJSON();
                         renderQueue = updateRenderQueue();
                     }
                 }
             ]);
-        })
+        };
+
+        targetElement.addEventListener("contextmenu", handleContextMenu);
+
+        return () => {
+            targetElement.removeEventListener("contextmenu", handleContextMenu);
+        };
     });
 
     interactivity({
@@ -354,7 +371,7 @@
         }
 
         if (block.action && allActions[block.category][block.action].subactions.length) {
-            let subactions: {name: str, text: str}[] = [];
+            let subactions: {name: string, text: string}[] = [];
             for (let cate of allActions[block.category][block.action].subactions) {
                 subactions.push(...Object.keys(allActions[cate]).map(k => {
                     let act = allActions[cate][k];
@@ -502,15 +519,49 @@
         for (let index of removingIndices) template.blocks.splice(index, 1);
     }
 
-    let selection = $state([]);
-    let startSelection: boolean | number = $state(false);
-    let movingSelection = $state(false);
+    let selection: number[] = $state([...rendererState.selection]);
+    let startSelection: number | null = $state(rendererState.startSelection);
+    let movingSelection = $state(rendererState.movingSelection);
+
+    function selectionEquals(a: number[], b: number[]): boolean {
+        if (a.length !== b.length) {
+            return false;
+        }
+        return a.every((value, index) => value === b[index]);
+    }
+
+    $effect(() => {
+        if (!selectionEquals(selection, rendererState.selection)) {
+            selection = [...rendererState.selection];
+        }
+        if (startSelection !== rendererState.startSelection) {
+            startSelection = rendererState.startSelection;
+        }
+        if (movingSelection !== rendererState.movingSelection) {
+            movingSelection = rendererState.movingSelection;
+        }
+    });
+
+    $effect(() => {
+        if (
+            !selectionEquals(selection, rendererState.selection) ||
+            startSelection !== rendererState.startSelection ||
+            movingSelection !== rendererState.movingSelection
+        ) {
+            rendererState = {
+                ...rendererState,
+                selection: [...selection],
+                startSelection,
+                movingSelection
+            };
+        }
+    });
 
     function selectBlocks(start: number | null, end?: number) {
         selection = [];
-        startSelection = false;
+        startSelection = null;
         movingSelection = false;
-        if (!start) return;
+        if (start === null || end === undefined) return;
 
         for (let index = start; index <= end; index++) {
             selection.push(index);
@@ -540,7 +591,7 @@
         e.stopImmediatePropagation();
         let options = [];
         if (selection.length == 0) {
-            if (!startSelection) {
+            if (startSelection === null) {
                 options.push({
                     label: "Select",
                     tooltip: "Select this code block.",
@@ -575,7 +626,7 @@
                 tooltip: "Deselect",
                 callback: () => {
                     selection = [];
-                    startSelection = false;
+                    startSelection = null;
                     movingSelection = false;
                 }
             });

--- a/src/lib/components/editor/Editor.svelte
+++ b/src/lib/components/editor/Editor.svelte
@@ -235,13 +235,13 @@
 
 <div class="container" class:mobile={isMobile.isMobile}>
     <div class="import-export">
-        <div style="position: relative">
+        <div style="position: relative; min-height: 0; min-width: 0;">
             <textarea
                     bind:value={templateDisplay}
                     oninput={inputTemplate}
                     onblur={updateTemplateJSON}
                     placeholder="Enter template JSON, compressed template JSON, or codetemplatedata..."
-                    style="overflow: scroll; resize: none; height: 100%; width: 100%; box-sizing: border-box; position: relative"
+                    style="overflow-y: auto; resize: none; height: 100%; width: 100%; box-sizing: border-box; position: relative"
                     autocomplete="off"
                     autocapitalize="off"
                     spellcheck="false"
@@ -250,7 +250,7 @@
         </div>
         <button onclick={sendTemplate}>Send Template</button>
     </div>
-    <div style="position: relative; height: 100%; min-height: 0; box-sizing: border-box;">
+    <div style="position: relative; height: 100%; min-height: 0; min-width: 0; box-sizing: border-box;">
         <CodeRenderer
                 bind:template={templateObject}
                 bind:editBlockIndex
@@ -296,6 +296,11 @@
         align-items: stretch;
     }
 
+    .container > * {
+        min-width: 0;
+        min-height: 0;
+    }
+
     .container.mobile {
         grid-template-columns: 1fr;
         grid-template-rows: 20% 1fr 20%;
@@ -307,6 +312,7 @@
         grid-template-columns: 1fr;
         gap: 20px;
         min-height: 0;
+        min-width: 0;
         height: 100%;
         box-sizing: border-box;
         align-items: stretch;

--- a/src/lib/components/editor/Editor.svelte
+++ b/src/lib/components/editor/Editor.svelte
@@ -127,13 +127,6 @@
 
     function updateTemplateJSON() {
         templateDisplay = JSON.stringify(templateObject.toJSON(), null, 4);
-        if (typeof window !== "undefined") {
-            let searchParams = new URLSearchParams(window.location.search);
-            searchParams.set("template", toURLSafeB64(templateObject.encodeTemplate()));
-            let loc = new URL(window.location.href);
-            loc.search = searchParams.toString();
-            replaceState(loc, null);
-        }
         setStatus("success");
     }
 

--- a/src/lib/components/editor/Editor.svelte
+++ b/src/lib/components/editor/Editor.svelte
@@ -1,18 +1,42 @@
 <script lang="ts">
-    import {Codeblock, Item, Template} from "$lib/diamondfire";
+    import { Codeblock, Item } from "$lib/diamondfire";
     import "svelte";
-    import { CodeClient } from "$lib/codeclient"
+    import { CodeClient } from "$lib/codeclient";
     import CodeRenderer from "$lib/components/editor/CodeRenderer.svelte";
     import ChestMenu from "$lib/components/editor/ChestMenu.svelte";
-    import {onMount, setContext} from "svelte";
+    import { setContext } from "svelte";
     import Inspector from "$lib/components/editor/Inspector.svelte";
-    import { setInspectorObjects } from "$lib/components/editor/Inspector.svelte";
-    import {CATEGORY_COLOR_MAP, secondLine, TYPE_DISPLAY_COLORS_MAP, TYPE_DISPLAY_MAP} from "$lib/df_reprs";
-    import {toURLSafeB64} from "$lib/utils.ts";
-    import {replaceState} from "$app/navigation";
-    import {getTemplateData} from "$lib/templatedata.ts";
+    import {
+        EDITOR_STATE_VERSION,
+        EDITOR_SUCCESS_MESSAGE,
+        type EditorRendererState,
+        type EditorSessionState,
+        type EditorStatusType,
+        type InspectorObject,
+        cloneEditorSessionState,
+        createEditorSessionState,
+        editorSessionStateSignature,
+        hydrateEditorSessionState
+    } from "$lib/components/editor/editor-state";
+    import { CATEGORY_COLOR_MAP, secondLine, TYPE_DISPLAY_COLORS_MAP, TYPE_DISPLAY_MAP } from "$lib/df_reprs";
+    import { toURLSafeB64 } from "$lib/utils.ts";
+    import { replaceState } from "$app/navigation";
+    import { getTemplateData } from "$lib/templatedata.ts";
 
-    let { template = "", containerWidth, containerHeight }: { template: str, containerWidth: number, containerHeight: number } = $props();
+    let {
+        template = "",
+        editorState = null,
+        onStateChange,
+        containerWidth,
+        containerHeight
+    }: {
+        template: string,
+        editorState: EditorSessionState | null,
+        onStateChange?: (state: EditorSessionState) => void,
+        containerWidth: number,
+        containerHeight: number
+    } = $props();
+
     $effect(() => {
         isMobile.isMobile = containerHeight == 0 ? false : containerWidth / containerHeight <= 9 / 10;
     });
@@ -21,26 +45,48 @@
     });
     setContext("editorMobile", isMobile);
 
-    let templateObject = $state((() => template)() ? Template.decodeTemplate((() => template)()) : new Template([]));
-    let templateDisplay = $state((() => template)() ? JSON.stringify((() => templateObject)().toJSON(), null, 4) : "");
+    const emptyState = createEditorSessionState();
 
-    let statusMessage = $state("");
+    let templateObject = $state(emptyState.templateObject);
+    let templateDisplay = $state(emptyState.state.templateInput);
+    let statusType = $state<EditorStatusType>(emptyState.state.status.type);
+    let statusMessage = $state(emptyState.state.status.message);
 
-    onMount(() => setStatus("success"));
+    let clickedChestIndex = $state(emptyState.state.ui.clickedChestIndex);
+    let editBlockIndex = $state(emptyState.state.ui.editBlockIndex);
+    let inspectingItem = $state(emptyState.state.ui.inspectingItem);
+    let freezeInDepthView = $state(emptyState.state.ui.freezeInDepthView);
+    let inspectingItemItem: Item | null = $state(null);
 
-    function setStatus(status: 'success' | 'error', msg?: string) {
-        document.getElementById("codeStatus").style.backgroundColor = "var(--" + status + ")";
-        if (status === 'success') {
-            statusMessage = "Code parsed successfully!";
+    let rendererState = $state<EditorRendererState>({
+        cameraXTarget: emptyState.state.renderer.cameraXTarget,
+        cameraZoomTarget: emptyState.state.renderer.cameraZoomTarget,
+        selection: [...emptyState.state.renderer.selection],
+        startSelection: emptyState.state.renderer.startSelection,
+        movingSelection: emptyState.state.renderer.movingSelection
+    });
+
+    let inspectorObjects = $state<InspectorObject[][] | null>(null);
+    let inspectorSpecialCase = $state(false);
+
+    function setInspectorObjects(iO: InspectorObject[][] | null) {
+        inspectorObjects = iO;
+        inspectorSpecialCase = false;
+    }
+
+    function setStatus(status: EditorStatusType, message?: string) {
+        statusType = status;
+        if (status === "success") {
+            statusMessage = EDITOR_SUCCESS_MESSAGE;
         } else {
-            statusMessage = msg;
+            statusMessage = message ?? "Cannot parse template.";
         }
     }
 
-    function inputTemplate(event: Event) {
-        template = (event.target as HTMLTextAreaElement).value.trim();
+    function inputTemplate() {
+        const templateInput = templateDisplay.trim();
 
-        const response = getTemplateData(template);
+        const response = getTemplateData(templateInput);
 
         switch (response.status) {
             case "success":
@@ -61,19 +107,16 @@
         codeclient.close();
     }
 
-    let clickedChestIndex = $state(-1);
-    let editBlockIndex = $state(-1);
-
     function clickChest(index: number) {
         clickedChestIndex = index;
     }
 
     function getInspectingTitle(): string {
-        let text: string;
-        let color: string;
+        let text = "";
+        let color = "white";
         if (clickedChestIndex != -1) {
             text = inspectingItemItem ? TYPE_DISPLAY_MAP[inspectingItemItem.id] : "";
-            color = inspectingItemItem ? TYPE_DISPLAY_COLORS_MAP[inspectingItemItem.id] : "";
+            color = inspectingItemItem ? TYPE_DISPLAY_COLORS_MAP[inspectingItemItem.id] : "white";
         }
         if (editBlockIndex != -1) {
             text = secondLine(templateObject.blocks[editBlockIndex] as Codeblock) || "&lt;empty&gt;";
@@ -84,25 +127,124 @@
 
     function updateTemplateJSON() {
         templateDisplay = JSON.stringify(templateObject.toJSON(), null, 4);
-        let searchParams = new URLSearchParams(window.location.search);
-        searchParams.set("template", toURLSafeB64(templateObject.encodeTemplate()));
-        let loc = new URL(window.location.href);
-        loc.search = searchParams.toString();
-        replaceState(loc, null);
-        inspectingTitle = getInspectingTitle();
+        if (typeof window !== "undefined") {
+            let searchParams = new URLSearchParams(window.location.search);
+            searchParams.set("template", toURLSafeB64(templateObject.encodeTemplate()));
+            let loc = new URL(window.location.href);
+            loc.search = searchParams.toString();
+            replaceState(loc, null);
+        }
         setStatus("success");
     }
 
-    let inspectingItem = $state(-1);
-    let freezeInDepthView = $state(false);
-    let inspectingItemItem: Item | null = $state(null);
+    function loadState(nextState: Partial<EditorSessionState> | null | undefined) {
+        const hydratedState = hydrateEditorSessionState(nextState, template);
+
+        templateObject = hydratedState.templateObject;
+        templateDisplay = hydratedState.state.templateInput;
+        statusType = hydratedState.state.status.type;
+        statusMessage = hydratedState.state.status.message;
+
+        clickedChestIndex = hydratedState.state.ui.clickedChestIndex;
+        editBlockIndex = hydratedState.state.ui.editBlockIndex;
+        inspectingItem = hydratedState.state.ui.inspectingItem;
+        freezeInDepthView = hydratedState.state.ui.freezeInDepthView;
+        inspectingItemItem = null;
+
+        rendererState = {
+            cameraXTarget: hydratedState.state.renderer.cameraXTarget,
+            cameraZoomTarget: hydratedState.state.renderer.cameraZoomTarget,
+            selection: [...hydratedState.state.renderer.selection],
+            startSelection: hydratedState.state.renderer.startSelection,
+            movingSelection: hydratedState.state.renderer.movingSelection
+        };
+
+        setInspectorObjects(null);
+    }
+
+    function buildSessionState(): EditorSessionState {
+        return cloneEditorSessionState({
+            version: EDITOR_STATE_VERSION,
+            templateInput: templateDisplay,
+            templateEncoded: templateObject.encodeTemplate(),
+            status: {
+                type: statusType,
+                message: statusMessage
+            },
+            ui: {
+                clickedChestIndex,
+                editBlockIndex,
+                inspectingItem,
+                freezeInDepthView
+            },
+            renderer: {
+                cameraXTarget: rendererState.cameraXTarget,
+                cameraZoomTarget: rendererState.cameraZoomTarget,
+                selection: [...rendererState.selection],
+                startSelection: rendererState.startSelection,
+                movingSelection: rendererState.movingSelection
+            }
+        });
+    }
+
+    let initialized = $state(false);
+    let lastPublishedStateSignature = $state("");
+
+    $effect(() => {
+        if (!initialized) {
+            loadState(editorState);
+            initialized = true;
+            return;
+        }
+
+        if (!editorState) {
+            return;
+        }
+
+        const hydratedIncomingState = hydrateEditorSessionState(editorState, template).state;
+        const incomingSignature = editorSessionStateSignature(hydratedIncomingState);
+        const currentSignature = editorSessionStateSignature(buildSessionState());
+
+        if (incomingSignature !== currentSignature && incomingSignature !== lastPublishedStateSignature) {
+            loadState(editorState);
+        }
+    });
+
+    $effect(() => {
+        if (!initialized) {
+            return;
+        }
+
+        templateDisplay;
+        statusType;
+        statusMessage;
+        clickedChestIndex;
+        editBlockIndex;
+        inspectingItem;
+        freezeInDepthView;
+        rendererState.cameraXTarget;
+        rendererState.cameraZoomTarget;
+        rendererState.selection;
+        rendererState.startSelection;
+        rendererState.movingSelection;
+
+        const nextState = buildSessionState();
+        const nextStateSignature = editorSessionStateSignature(nextState);
+
+        if (nextStateSignature !== lastPublishedStateSignature) {
+            lastPublishedStateSignature = nextStateSignature;
+            onStateChange?.(nextState);
+        }
+    });
+
     let inspectingTitle = $derived.by(getInspectingTitle);
 </script>
 
 <div class="container" class:mobile={isMobile.isMobile}>
-    <div id="import-export">
+    <div class="import-export">
         <div style="position: relative">
             <textarea
+                    bind:value={templateDisplay}
                     oninput={inputTemplate}
                     onblur={updateTemplateJSON}
                     placeholder="Enter template JSON, compressed template JSON, or codetemplatedata..."
@@ -110,8 +252,8 @@
                     autocomplete="off"
                     autocapitalize="off"
                     spellcheck="false"
-            >{templateDisplay}</textarea>
-            <div id="codeStatus" title={statusMessage}></div>
+            ></textarea>
+            <div class="code-status" title={statusMessage} style:background-color={"var(--" + statusType + ")"}></div>
         </div>
         <button onclick={sendTemplate}>Send Template</button>
     </div>
@@ -119,7 +261,10 @@
         <CodeRenderer
                 bind:template={templateObject}
                 bind:editBlockIndex
+                bind:rendererState
                 {clickChest}
+                clearInspector={() => setInspectorObjects(null)}
+                {setInspectorObjects}
                 {updateTemplateJSON}
         ></CodeRenderer>
         <ChestMenu
@@ -130,15 +275,17 @@
                 blockIndex={clickedChestIndex}
                 visible={clickedChestIndex !== -1}
                 dismiss={() => clickedChestIndex = -1}
+                {inspectorSpecialCase}
                 {setInspectorObjects}
                 {updateTemplateJSON}
         ></ChestMenu>
     </div>
     <Inspector
-            bind:template={templateObject}
             bind:inspectingItem
             bind:freezeInDepthView
             bind:inspectingItemItem
+            bind:inspectorObjects
+            bind:inspectorSpecialCase
             {inspectingTitle}
             {updateTemplateJSON}
     ></Inspector>
@@ -160,7 +307,8 @@
         grid-template-columns: 1fr;
         grid-template-rows: 20% 1fr 20%;
     }
-    #import-export {
+
+    .import-export {
         display: grid;
         grid-template-rows: 3fr 1fr;
         grid-template-columns: 1fr;
@@ -170,12 +318,13 @@
         box-sizing: border-box;
         align-items: stretch;
     }
-    .mobile #import-export {
+
+    .mobile .import-export {
         grid-template-rows: 1fr;
         grid-template-columns: 3fr 1fr;
     }
 
-    #codeStatus {
+    .code-status {
         position: absolute;
         bottom: 10px;
         left: 10px;

--- a/src/lib/components/editor/Inspector.svelte
+++ b/src/lib/components/editor/Inspector.svelte
@@ -63,7 +63,7 @@
 <div
         class="container coolContainer"
         oncreate={ref => inDepthElement = ref}
-        style="display: flex; flex-direction: column; position: relative; cursor: auto; overflow: scroll"
+        style="display: flex; flex-direction: column; position: relative; cursor: auto; overflow-y: auto; min-height: 0; min-width: 0;"
 >
     <div>
         <span style="font-size: 20px; display: inline">Inspector</span>

--- a/src/lib/components/editor/Inspector.svelte
+++ b/src/lib/components/editor/Inspector.svelte
@@ -119,7 +119,6 @@
                                     value={inspectorObject.get() ?? ""}
                                     oninput={e => {
                                         const value = (e.target as HTMLInputElement).value;
-                                        // Solo actualizar si no está vacío
                                         if (value !== "") {
                                             inspectorObject.set(parseFloat(value));
                                             updateTemplateJSON();
@@ -127,7 +126,6 @@
                                     }}
                                     onblur={e => {
                                         const value = (e.target as HTMLInputElement).value;
-                                        // Si quedó vacío después de salir, guardar como 0
                                         if (value === "") {
                                             inspectorObject.set(0);
                                             updateTemplateJSON();
@@ -158,7 +156,6 @@
                                     value={(inspectorObject.get() * 100).toString()}
                                     oninput={e => {
                                         const value = (e.target as HTMLInputElement).value;
-                                        // Solo actualizar si no está vacío
                                         if (value !== "") {
                                             inspectorObject.set(parseFloat(value) / 100);
                                             updateTemplateJSON();

--- a/src/lib/components/editor/Inspector.svelte
+++ b/src/lib/components/editor/Inspector.svelte
@@ -5,6 +5,7 @@
     import MiniMessageRenderer from "$lib/components/MiniMessageRenderer.svelte";
     import { fastRender } from "$lib/minimessage";
     import DropDown from "$lib/components/DropDown.svelte";
+    import { getContext } from "svelte";
     import type { InspectorObject } from "$lib/components/editor/editor-state";
 
     let {
@@ -26,6 +27,7 @@
     } = $props();
 
     let inDepthElement: HTMLDivElement | null = $state(null);
+    let isMobile: boolean = $derived(getContext("editorMobile").isMobile);
 
     function getPlaceholder(inspectorObject: InspectorObject) {
         if (inspectorObject.placeholder) return inspectorObject.placeholder;
@@ -65,15 +67,15 @@
         oncreate={ref => inDepthElement = ref}
         style="display: flex; flex-direction: column; position: relative; cursor: auto; overflow-y: auto; min-height: 0; min-width: 0;"
 >
-    <div>
+    <div style="display: flex; justify-content: space-between; align-items: {isMobile ? 'flex-start' : 'center'}; flex-wrap: wrap; gap: 10px;">
         <span style="font-size: 20px; display: inline">Inspector</span>
         {#if freezeInDepthView}
-            <span style="position: absolute; top: 25px; right: 20px; font-size: 13px; display: inline;">Click elsewhere to unfocus.</span>
+            <span style="font-size: 13px; display: inline; text-align: right;">Click elsewhere to unfocus.</span>
         {:else}
-            <span style="position: absolute; top: 25px; right: 20px; font-size: 13px; display: inline;">Click an item to focus inspector.</span>
+            <span style="font-size: 13px; display: inline; text-align: right;">Click an item to focus inspector.</span>
         {/if}
         {#if inspectorObjects !== null}
-            <div style="margin-top: 10px; font-size: 20px">{@html fastRender(inspectingTitle)}</div>
+            <div style="margin-top: 10px; font-size: 20px; width: 100%;">{@html fastRender(inspectingTitle)}</div>
         {/if}
     </div>
     <form onsubmit={e => e.preventDefault()} style="display: flex; gap: 10px; flex-direction: column; margin-top: 25px;">

--- a/src/lib/components/editor/Inspector.svelte
+++ b/src/lib/components/editor/Inspector.svelte
@@ -114,13 +114,23 @@
                                     type="number"
                                     id={inspectorObject.id}
                                     name={inspectorObject.id}
-                                    bind:value={
-                                        () => inspectorObject.get() ?? "",
-                                        v => {
-                                            inspectorObject.set(v);
+                                    value={inspectorObject.get() ?? ""}
+                                    oninput={e => {
+                                        const value = (e.target as HTMLInputElement).value;
+                                        // Solo actualizar si no está vacío
+                                        if (value !== "") {
+                                            inspectorObject.set(parseFloat(value));
                                             updateTemplateJSON();
                                         }
-                                    }
+                                    }}
+                                    onblur={e => {
+                                        const value = (e.target as HTMLInputElement).value;
+                                        // Si quedó vacío después de salir, guardar como 0
+                                        if (value === "") {
+                                            inspectorObject.set(0);
+                                            updateTemplateJSON();
+                                        }
+                                    }}
                                     placeholder={getPlaceholder(inspectorObject)}
                             />
                         {:else if inspectorObject.type === 'ColorField'}
@@ -143,13 +153,15 @@
                                     type="number"
                                     id={inspectorObject.id}
                                     name={inspectorObject.id}
-                                    bind:value={
-                                        () => (inspectorObject.get() * 100).toString(),
-                                        v => {
-                                            inspectorObject.set(v / 100);
+                                    value={(inspectorObject.get() * 100).toString()}
+                                    oninput={e => {
+                                        const value = (e.target as HTMLInputElement).value;
+                                        // Solo actualizar si no está vacío
+                                        if (value !== "") {
+                                            inspectorObject.set(parseFloat(value) / 100);
                                             updateTemplateJSON();
                                         }
-                                    }
+                                    }}
                                     placeholder={getPlaceholder(inspectorObject)}
                                     min="0"
                                     max="100"

--- a/src/lib/components/editor/Inspector.svelte
+++ b/src/lib/components/editor/Inspector.svelte
@@ -1,45 +1,26 @@
-<script module lang="ts">
-    export type InspectorObject = {
-        label: string,
-        type: 'StringField' | 'DropDown' | 'NumberField' | 'MiniMessageField' | 'ColorField' | 'PercentageField' | 'BooleanField' | 'ItemField',
-        multiline?: boolean,
-        id: string,
-        options?: { text: string, name: string }[],
-        set: (data: string) => void,
-        get: () => string,
-        placeholder?: string
-    };
-    let inspectorObjects: InspectorObject[][] | null = $state(null);
-    let innerFreeze = $state(false);
-    export function setInspectorObjects(iO: InspectorObject[][] | null) {
-        inspectorObjects = iO;
-        innerFreeze = false;
-    }
-    export function isSpecialCase(): boolean {
-        return innerFreeze;
-    }
-</script>
-
 <script lang="ts">
-    import {Item, type Template, VALUE_TYPES} from "$lib/diamondfire";
+    import { Item, VALUE_TYPES } from "$lib/diamondfire";
     import Checkbox from "$lib/components/Checkbox.svelte";
     import ChestMenuItem from "$lib/components/editor/ChestMenuItem.svelte";
     import MiniMessageRenderer from "$lib/components/MiniMessageRenderer.svelte";
-    import {fastRender} from "$lib/minimessage";
+    import { fastRender } from "$lib/minimessage";
     import DropDown from "$lib/components/DropDown.svelte";
+    import type { InspectorObject } from "$lib/components/editor/editor-state";
 
     let {
-        template = $bindable(),
         inspectingItem = $bindable(),
         inspectingItemItem = $bindable(),
         freezeInDepthView = $bindable(),
+        inspectorObjects = $bindable<InspectorObject[][] | null>(null),
+        inspectorSpecialCase = $bindable(false),
         updateTemplateJSON,
         inspectingTitle
     }: {
-        template: Template,
         inspectingItem: number,
-        inspectingItemItem: Item,
+        inspectingItemItem: Item | null,
         freezeInDepthView: boolean,
+        inspectorObjects: InspectorObject[][] | null,
+        inspectorSpecialCase: boolean,
         updateTemplateJSON: () => void,
         inspectingTitle: string
     } = $props();
@@ -48,7 +29,7 @@
 
     function getPlaceholder(inspectorObject: InspectorObject) {
         if (inspectorObject.placeholder) return inspectorObject.placeholder;
-        let dataType = {StringField: "string", NumberField: "number", MiniMessageField: "minimessage", ColorField: "color", PercentageField: "percent"}[inspectorObject.type];
+        let dataType = { StringField: "string", NumberField: "number", MiniMessageField: "minimessage", ColorField: "color", PercentageField: "percent" }[inspectorObject.type];
         return `${inspectorObject.label} (${dataType})`;
     }
 
@@ -66,7 +47,7 @@
     }
 
     function pointerMove(event: PointerEvent) {
-        if (tooltip !== null) {
+        if (tooltip !== null && tooltipElement !== null) {
             tooltipX = event.clientX - tooltipElement.offsetWidth - 5;
             tooltipY = event.clientY - 5;
         }
@@ -74,9 +55,9 @@
 
     $effect(() => {
         if (!freezeInDepthView) {
-            innerFreeze = false;
+            inspectorSpecialCase = false;
         }
-    })
+    });
 </script>
 
 <div
@@ -107,7 +88,7 @@
                                         id={inspectorObject.id}
                                         name={inspectorObject.id}
                                         oninput={e => {
-                                            inspectorObject.set(document.getElementById(inspectorObject.id).value);
+                                            inspectorObject.set((e.target as HTMLTextAreaElement).value);
                                             updateTemplateJSON();
                                         }}
                                         placeholder={getPlaceholder(inspectorObject)}
@@ -205,7 +186,7 @@
                             ></DropDown>
                         {:else if inspectorObject.type === 'ItemField'}
                             <ChestMenuItem
-                                    bind:freezeInDepthView={innerFreeze}
+                                    bind:freezeInDepthView={inspectorSpecialCase}
                                     deleteItemCb={() => {
                                         inspectorObject.set(null);
                                         inspectorObjects = inspectorObjects.map(row =>
@@ -218,7 +199,7 @@
                                         updateTemplateJSON();
                                     }}
                                     newItemCb={(value: Item) => {
-                                        inspectorObject.set(value)
+                                        inspectorObject.set(value);
                                         inspectorObjects = inspectorObjects.map(row =>
                                             row.map(io =>
                                                 io === inspectorObject
@@ -242,9 +223,9 @@
                                     setThisToInspectingItem={() => {
                                         inspectingItem = -1;
                                         inspectingItemItem = inspectorObject.get();
-                                        setTooltipThis(null);
+                                        setTooltipThis(null, null);
                                     }}
-                                    doInspect={() => innerFreeze}
+                                    doInspect={() => inspectorSpecialCase}
                                     innerItem={inspectorObject.get()}
                                     nullItemBehavior={() => null}
                                     allowedItemsList={VALUE_TYPES}

--- a/src/lib/components/editor/Item.svelte
+++ b/src/lib/components/editor/Item.svelte
@@ -35,7 +35,7 @@
         TextComponentConverter,
         validateText, getColorHex
     } from "$lib/minecraft_text";
-    import { type InspectorObject } from "$lib/components/editor/Inspector.svelte";
+    import { type InspectorObject } from "$lib/components/editor/editor-state";
     import { miniMessage } from "$lib/minimessage"
     import {getContext, onMount} from "svelte";
     import {ComponentHTMLConverter, escapeHtml} from "$lib/minecraft_text.ts";
@@ -54,7 +54,7 @@
         item: Item,
         set: (item: Item) => void;
         setTooltip: (data: string, spanColor: string | null, direct?: boolean) => void,
-        setInspectorObjects: (inspectorObjects: InspectorObject[][], cond: boolean) => void,
+        setInspectorObjects: (inspectorObjects: InspectorObject[][] | null) => void,
         clearItem: () => void
     } = $props();
 

--- a/src/lib/components/editor/Item.svelte
+++ b/src/lib/components/editor/Item.svelte
@@ -70,7 +70,12 @@
     function set(item: Item) {
         setParent(item);
         if (tooltipShowing) {
-            renderTooltip();
+            try {
+                renderTooltip();
+            } catch (error) {
+                console.error("Error rendering tooltip:", error);
+                // Silently continue - don't crash the inspector
+            }
         }
     }
 
@@ -83,7 +88,8 @@
     }
 
     function attrtxt(label: string, data: any, dataCol: string = "white", prepend: boolean = true): string {
-        return (prepend ? "<br>" : "") + `<gray>${label}: </gray><${dataCol}>${escapeHtml(data.toString())}</${dataCol}>`
+        const dataStr = data == null ? "(empty)" : escapeHtml(data.toString());
+        return (prepend ? "<br>" : "") + `<gray>${label}: </gray><${dataCol}>${dataStr}</${dataCol}>`;
     }
 
     function renderTooltip(doTooltip = true) {
@@ -215,23 +221,39 @@
             }
             setInspectorObjects([line]);
         } else if (item instanceof SoundItem) {
-            let variantText = item.variant ? attrtxt("Variant", item.variant) : ""
-            setTooltip(`<white>${escapeHtml(item.sound)}</white>${escapeHtml(variantText)}${attrtxt("Pitch", item.pitch)}${attrtxt("Volume", item.volume)}`);
-            let allSounds = Object.keys(actiondump.sounds).map(sound => {
+            let variantText = item.variant ? attrtxt("Variant", item.variant) : "";
+            let pitchText = item.pitch != null ? attrtxt("Pitch", item.pitch) : "";
+            let volumeText = item.volume != null ? attrtxt("Volume", item.volume) : "";
+            setTooltip(`<white>${escapeHtml(item.sound || "(empty)")}</white>${variantText}${pitchText}${volumeText}`);
+            
+            let allSounds = Object.keys(actiondump.sounds || {}).map(sound => {
                 return {
                     text: sound,
                     name: sound
                 }
             });
-            let variants = actiondump.sounds[item.sound].variants.map(variant => {
-                return {
-                    text: variant,
-                    name: variant
+            
+            let variants = [];
+            try {
+                if (item.sound && actiondump.sounds?.[item.sound]?.variants) {
+                    variants = actiondump.sounds[item.sound].variants.map(variant => {
+                        return {
+                            text: variant,
+                            name: variant
+                        }
+                    });
                 }
-            }) || [{
-                text: "",
-                name: null
-            }];
+            } catch (error) {
+                console.warn("Error loading sound variants:", error);
+            }
+            
+            if (variants.length === 0) {
+                variants = [{
+                    text: "(none)",
+                    name: null
+                }];
+            }
+            
             setInspectorObjects([
                 [
                     {
@@ -281,21 +303,27 @@
                 ],
             ]);
         } else if (item instanceof ParticleItem) {
-            let allowedAttributes: string[] = actiondump.particles[actiondump.particle_category_reverse_map[item.particle]][item.particle].fields;
+            try {
+                let categoryMap = actiondump.particle_category_reverse_map?.[item.particle];
+                let particleData = actiondump.particles?.[categoryMap]?.[item.particle];
+                let allowedAttributes: string[] = particleData?.fields ?? [];
 
-            let attrText = attrtxt("Amount", item.amount) + attrtxt("Spread", (item.spread[0].toString()) + " " + (item.spread[1].toString()));
-            if (allowedAttributes) {
-                attrText += "<br>";
-            }
+                let attrText = attrtxt("Amount", item.amount);
+                if (item.spread && item.spread.length >= 2) {
+                    attrText += attrtxt("Spread", (item.spread[0]?.toString?.() ?? "0") + " " + (item.spread[1]?.toString?.() ?? "0"));
+                }
+                if (allowedAttributes && allowedAttributes.length > 0) {
+                    attrText += "<br>";
+                }
 
-            let attributeOptions = [];
+                let attributeOptions = [];
 
-            for (let attr of allowedAttributes) {
-                if (attr == "Color") {
-                    let col = convert.rgb.hex(item.color) ?? "ff0000";
-                    attrText += attrtxt("Color", "#" + col.toUpperCase(), "#" + col);
-                    attributeOptions.push([{
-                        label: "Color",
+                for (let attr of allowedAttributes) {
+                    if (attr == "Color") {
+                        let col = convert.rgb.hex(item.color) ?? "ff0000";
+                        attrText += attrtxt("Color", "#" + col.toUpperCase(), "#" + col);
+                        attributeOptions.push([{
+                            label: "Color",
                         id: "color",
                         type: "ColorField",
                         set: (data) => {
@@ -551,6 +579,11 @@
                     },
                 ]
             ].concat(attributeOptions));
+            } catch (error) {
+                console.error("Error rendering particle inspector:", error);
+                setTooltip(`<red>Error loading particle data</red>`);
+                setInspectorObjects(null);
+            }
         } else if (item instanceof VectorItem) {
             setTooltip("<" + TYPE_DISPLAY_COLORS_MAP.vec + ">Vector<reset><br>" + attrtxt("X", item.x, "white", false) + attrtxt("Y", item.y) + attrtxt("Z", item.z));
             setInspectorObjects([

--- a/src/lib/components/editor/editor-state.ts
+++ b/src/lib/components/editor/editor-state.ts
@@ -184,10 +184,28 @@ export function createEditorSessionState(templateInput: string = ""): { state: E
     };
 }
 
-export function hydrateEditorSessionState(incomingState: Partial<EditorSessionState> | null | undefined, fallbackTemplateInput: string = ""): { state: EditorSessionState; templateObject: Template } {
-    const fallback = createEditorSessionState(fallbackTemplateInput);
+export function hydrateEditorSessionState(incomingState: Partial<EditorSessionState> | null | undefined, fallbackTemplateJSON: string = ""): { state: EditorSessionState; templateObject: Template } {
+    const fallback = createEditorSessionState(fallbackTemplateJSON);
 
     if (!incomingState) {
+        // When no state, try to parse fallbackTemplateJSON as JSON
+        if (fallbackTemplateJSON.trim()) {
+            const parsed = getTemplateData(fallbackTemplateJSON);
+            if (parsed.status === "success") {
+                const templateObject = parsed.templateObject;
+                return {
+                    state: {
+                        version: EDITOR_STATE_VERSION,
+                        templateInput: JSON.stringify(templateObject.toJSON(), null, 4),
+                        templateEncoded: templateObject.encodeTemplate(),
+                        status: { type: "success", message: EDITOR_SUCCESS_MESSAGE },
+                        ui: fallback.state.ui,
+                        renderer: fallback.state.renderer
+                    },
+                    templateObject
+                };
+            }
+        }
         return fallback;
     }
 

--- a/src/lib/components/editor/editor-state.ts
+++ b/src/lib/components/editor/editor-state.ts
@@ -1,0 +1,239 @@
+import { Template } from "$lib/diamondfire";
+import { getTemplateData } from "$lib/templatedata";
+
+export type InspectorObject = {
+    label: string;
+    type: "StringField" | "DropDown" | "NumberField" | "MiniMessageField" | "ColorField" | "PercentageField" | "BooleanField" | "ItemField";
+    multiline?: boolean;
+    id: string;
+    options?: { text: string; name: string }[];
+    set: (data: any) => void;
+    get: () => any;
+    placeholder?: string;
+};
+
+export type EditorStatusType = "success" | "error";
+
+export type EditorStatus = {
+    type: EditorStatusType;
+    message: string;
+};
+
+export type EditorUIState = {
+    clickedChestIndex: number;
+    editBlockIndex: number;
+    inspectingItem: number;
+    freezeInDepthView: boolean;
+};
+
+export type EditorRendererState = {
+    cameraXTarget: number;
+    cameraZoomTarget: number;
+    selection: number[];
+    startSelection: number | null;
+    movingSelection: boolean;
+};
+
+export type EditorSessionState = {
+    version: 1;
+    templateInput: string;
+    templateEncoded: string;
+    status: EditorStatus;
+    ui: EditorUIState;
+    renderer: EditorRendererState;
+};
+
+export const EDITOR_STATE_VERSION = 1 as const;
+export const EDITOR_SUCCESS_MESSAGE = "Code parsed successfully!";
+
+export function createDefaultEditorUIState(): EditorUIState {
+    return {
+        clickedChestIndex: -1,
+        editBlockIndex: -1,
+        inspectingItem: -1,
+        freezeInDepthView: false
+    };
+}
+
+export function createDefaultEditorRendererState(): EditorRendererState {
+    return {
+        cameraXTarget: 0,
+        cameraZoomTarget: 0,
+        selection: [],
+        startSelection: null,
+        movingSelection: false
+    };
+}
+
+function parseTemplateInput(templateInput: string): { templateObject: Template; status: EditorStatus; normalizedInput: string } {
+    const normalizedInput = templateInput.trim();
+    const response = getTemplateData(normalizedInput);
+
+    if (response.status === "success") {
+        return {
+            templateObject: response.templateObject,
+            status: {
+                type: "success",
+                message: EDITOR_SUCCESS_MESSAGE
+            },
+            normalizedInput
+        };
+    }
+
+    return {
+        templateObject: new Template([]),
+        status: {
+            type: "error",
+            message: response.message
+        },
+        normalizedInput
+    };
+}
+
+function decodeTemplateSafe(templateEncoded: string): Template | null {
+    if (templateEncoded.trim().length === 0) {
+        return new Template([]);
+    }
+
+    try {
+        return Template.decodeTemplate(templateEncoded);
+    } catch {
+        return null;
+    }
+}
+
+function normalizeStatus(status: Partial<EditorStatus> | undefined, fallback: EditorStatus): EditorStatus {
+    const type: EditorStatusType = status?.type === "error" ? "error" : "success";
+    const message = typeof status?.message === "string" && status.message.length > 0
+        ? status.message
+        : (type === "success" ? EDITOR_SUCCESS_MESSAGE : fallback.message);
+
+    return {
+        type,
+        message
+    };
+}
+
+function normalizeUIState(ui: Partial<EditorUIState> | undefined): EditorUIState {
+    const defaults = createDefaultEditorUIState();
+
+    return {
+        clickedChestIndex: Number.isInteger(ui?.clickedChestIndex) ? (ui?.clickedChestIndex as number) : defaults.clickedChestIndex,
+        editBlockIndex: Number.isInteger(ui?.editBlockIndex) ? (ui?.editBlockIndex as number) : defaults.editBlockIndex,
+        inspectingItem: Number.isInteger(ui?.inspectingItem) ? (ui?.inspectingItem as number) : defaults.inspectingItem,
+        freezeInDepthView: typeof ui?.freezeInDepthView === "boolean" ? ui.freezeInDepthView : defaults.freezeInDepthView
+    };
+}
+
+function normalizeRendererState(renderer: Partial<EditorRendererState> | undefined): EditorRendererState {
+    const defaults = createDefaultEditorRendererState();
+
+    const selection = Array.isArray(renderer?.selection)
+        ? renderer.selection.filter((index): index is number => Number.isInteger(index)).map(index => Math.trunc(index))
+        : defaults.selection;
+
+    return {
+        cameraXTarget: typeof renderer?.cameraXTarget === "number" ? renderer.cameraXTarget : defaults.cameraXTarget,
+        cameraZoomTarget: typeof renderer?.cameraZoomTarget === "number" ? renderer.cameraZoomTarget : defaults.cameraZoomTarget,
+        selection: [...selection],
+        startSelection: Number.isInteger(renderer?.startSelection) ? (renderer?.startSelection as number) : defaults.startSelection,
+        movingSelection: typeof renderer?.movingSelection === "boolean" ? renderer.movingSelection : defaults.movingSelection
+    };
+}
+
+export function cloneEditorSessionState(state: EditorSessionState): EditorSessionState {
+    return {
+        version: EDITOR_STATE_VERSION,
+        templateInput: state.templateInput,
+        templateEncoded: state.templateEncoded,
+        status: {
+            type: state.status.type,
+            message: state.status.message
+        },
+        ui: {
+            clickedChestIndex: state.ui.clickedChestIndex,
+            editBlockIndex: state.ui.editBlockIndex,
+            inspectingItem: state.ui.inspectingItem,
+            freezeInDepthView: state.ui.freezeInDepthView
+        },
+        renderer: {
+            cameraXTarget: state.renderer.cameraXTarget,
+            cameraZoomTarget: state.renderer.cameraZoomTarget,
+            selection: [...state.renderer.selection],
+            startSelection: state.renderer.startSelection,
+            movingSelection: state.renderer.movingSelection
+        }
+    };
+}
+
+export function createEditorSessionState(templateInput: string = ""): { state: EditorSessionState; templateObject: Template } {
+    const { templateObject, status, normalizedInput } = parseTemplateInput(templateInput);
+
+    const state: EditorSessionState = {
+        version: EDITOR_STATE_VERSION,
+        templateInput: normalizedInput,
+        templateEncoded: templateObject.encodeTemplate(),
+        status,
+        ui: createDefaultEditorUIState(),
+        renderer: createDefaultEditorRendererState()
+    };
+
+    return {
+        state,
+        templateObject
+    };
+}
+
+export function hydrateEditorSessionState(incomingState: Partial<EditorSessionState> | null | undefined, fallbackTemplateInput: string = ""): { state: EditorSessionState; templateObject: Template } {
+    const fallback = createEditorSessionState(fallbackTemplateInput);
+
+    if (!incomingState) {
+        return fallback;
+    }
+
+    const templateInput = typeof incomingState.templateInput === "string"
+        ? incomingState.templateInput
+        : fallback.state.templateInput;
+
+    let templateObject = decodeTemplateSafe(typeof incomingState.templateEncoded === "string" ? incomingState.templateEncoded : "");
+
+    if (templateObject === null) {
+        const parsed = getTemplateData(templateInput.trim());
+        if (parsed.status === "success") {
+            templateObject = parsed.templateObject;
+        } else {
+            templateObject = fallback.templateObject;
+        }
+    }
+
+    const state: EditorSessionState = {
+        version: EDITOR_STATE_VERSION,
+        templateInput,
+        templateEncoded: templateObject.encodeTemplate(),
+        status: normalizeStatus(incomingState.status, fallback.state.status),
+        ui: normalizeUIState(incomingState.ui),
+        renderer: normalizeRendererState(incomingState.renderer)
+    };
+
+    return {
+        state,
+        templateObject
+    };
+}
+
+export function editorSessionStateSignature(state: EditorSessionState): string {
+    return JSON.stringify({
+        version: state.version,
+        templateInput: state.templateInput,
+        templateEncoded: state.templateEncoded,
+        status: state.status,
+        ui: state.ui,
+        renderer: {
+            cameraXTarget: state.renderer.cameraXTarget,
+            cameraZoomTarget: state.renderer.cameraZoomTarget,
+            selection: state.renderer.selection,
+            startSelection: state.renderer.startSelection,
+            movingSelection: state.renderer.movingSelection
+        }
+    });
+}

--- a/src/lib/components/editor/tabs-state.ts
+++ b/src/lib/components/editor/tabs-state.ts
@@ -1,0 +1,90 @@
+import type { EditorSessionState } from "$lib/components/editor/editor-state";
+
+export type EditorTab = {
+    id: string;
+    name: string;
+    template: string;
+    editorState: EditorSessionState | null;
+};
+
+export type TabsState = {
+    tabs: EditorTab[];
+    activeTabId: string;
+};
+
+let tabCounter = 0;
+
+function generateTabId(): string {
+    return `tab-${Date.now()}-${tabCounter++}`;
+}
+
+export function createDefaultTab(template: string = ""): EditorTab {
+    return {
+        id: generateTabId(),
+        name: `Template ${tabCounter}`,
+        template,
+        editorState: null
+    };
+}
+
+export function createDefaultTabsState(initialTemplate: string = ""): TabsState {
+    const firstTab = createDefaultTab(initialTemplate);
+    return {
+        tabs: [firstTab],
+        activeTabId: firstTab.id
+    };
+}
+
+export function getActiveTab(state: TabsState): EditorTab | null {
+    return state.tabs.find(tab => tab.id === state.activeTabId) ?? null;
+}
+
+export function addTab(state: TabsState, template: string = ""): TabsState {
+    const newTab = createDefaultTab(template);
+    return {
+        tabs: [...state.tabs, newTab],
+        activeTabId: newTab.id
+    };
+}
+
+export function removeTab(state: TabsState, tabId: string): TabsState {
+    const newTabs = state.tabs.filter(tab => tab.id !== tabId);
+    
+    if (newTabs.length === 0) {
+        // Always keep at least one tab
+        return {
+            tabs: [createDefaultTab()],
+            activeTabId: newTabs[0]?.id ?? createDefaultTab().id
+        };
+    }
+
+    const newActiveId = state.activeTabId === tabId 
+        ? newTabs[newTabs.length - 1]!.id
+        : state.activeTabId;
+
+    return {
+        tabs: newTabs,
+        activeTabId: newActiveId
+    };
+}
+
+export function switchTab(state: TabsState, tabId: string): TabsState {
+    if (state.tabs.find(tab => tab.id === tabId)) {
+        return {
+            ...state,
+            activeTabId: tabId
+        };
+    }
+    return state;
+}
+
+export function updateTabState(state: TabsState, tabId: string, editorState: EditorSessionState, template: string): TabsState {
+    return {
+        ...state,
+        tabs: state.tabs.map(tab =>
+            tab.id === tabId
+                ? { ...tab, editorState, template }
+                : tab
+        )
+    };
+}

--- a/src/lib/components/editor/tabs-state.ts
+++ b/src/lib/components/editor/tabs-state.ts
@@ -1,9 +1,14 @@
-import type { EditorSessionState } from "$lib/components/editor/editor-state";
+import type { EditorSessionState } from "./editor-state";
+import { getTemplateData } from "../../templatedata";
+import { firstLine, secondLine } from "../../df_reprs";
+import { Codeblock } from "../../diamondfire";
 
 export type EditorTab = {
     id: string;
     name: string;
-    template: string;
+    icon: string | null;
+    showOnlyIcon: boolean;
+    template: string; // JSON format
     editorState: EditorSessionState | null;
 };
 
@@ -13,16 +18,60 @@ export type TabsState = {
 };
 
 let tabCounter = 0;
+const TAB_DEFAULT_NAME = "New Tab";
 
 function generateTabId(): string {
     return `tab-${Date.now()}-${tabCounter++}`;
 }
 
-export function createDefaultTab(template: string = ""): EditorTab {
+function parseTemplate(template: string) {
+    const result = getTemplateData(template);
+    return result.status === "success" ? result.templateObject : null;
+}
+
+function getTabName(templateJSON: string): string {
+    const templateObject = parseTemplate(templateJSON);
+    if (!templateObject || !templateObject.blocks.length) {
+        return TAB_DEFAULT_NAME;
+    }
+
+    const firstBlock = templateObject.blocks[0];
+    if (!(firstBlock instanceof Codeblock)) {
+        return TAB_DEFAULT_NAME;
+    }
+
+    const action = secondLine(firstBlock);
+    if (action && action.trim().length > 0) {
+        return action;
+    }
+
+    // If there's a block but no action, return empty string (will show only icon)
+    return "";
+}
+
+function getTabIcon(templateJSON: string): string | null {
+    const templateObject = parseTemplate(templateJSON);
+    if (!templateObject || !templateObject.blocks.length) {
+        return null;
+    }
+
+    const firstBlock = templateObject.blocks[0];
+    if (!(firstBlock instanceof Codeblock)) {
+        return null;
+    }
+
+    return `/textures/${firstBlock.category}.png`;
+}
+
+export function createDefaultTab(templateJSON: string = ""): EditorTab {
+    const name = getTabName(templateJSON);
+    const icon = getTabIcon(templateJSON);
     return {
         id: generateTabId(),
-        name: `Template ${tabCounter}`,
-        template,
+        name,
+        icon,
+        showOnlyIcon: name === "" && icon !== null,
+        template: templateJSON,
         editorState: null
     };
 }
@@ -79,11 +128,20 @@ export function switchTab(state: TabsState, tabId: string): TabsState {
 }
 
 export function updateTabState(state: TabsState, tabId: string, editorState: EditorSessionState, template: string): TabsState {
+    const name = getTabName(template);
+    const icon = getTabIcon(template);
     return {
         ...state,
         tabs: state.tabs.map(tab =>
             tab.id === tabId
-                ? { ...tab, editorState, template }
+                ? {
+                    ...tab,
+                    editorState,
+                    template,
+                    name,
+                    icon,
+                    showOnlyIcon: name === "" && icon !== null
+                }
                 : tab
         )
     };

--- a/src/routes/editor/+page.svelte
+++ b/src/routes/editor/+page.svelte
@@ -1,28 +1,108 @@
 <script lang="ts">
+    import { browser } from "$app/environment";
     import Editor from "$lib/components/editor/Editor.svelte";
     import type { EditorSessionState } from "$lib/components/editor/editor-state";
     import type { TabsState } from "$lib/components/editor/tabs-state";
-    import { createDefaultTabsState, getActiveTab, addTab, removeTab, switchTab, updateTabState } from "$lib/components/editor/tabs-state";
+    import { 
+        createDefaultTabsState, 
+        createDefaultTab,
+        getActiveTab, 
+        addTab, 
+        removeTab, 
+        switchTab, 
+        updateTabState 
+    } from "$lib/components/editor/tabs-state";
+    import { toURLSafeB64 } from "$lib/utils";
+    import { replaceState } from "$app/navigation";
+    import { getTemplateData } from "$lib/templatedata";
 
-    let {data} = $props();
+    let { data } = $props();
 
     let containerWidth: number = $state(0);
     let containerHeight: number = $state(0);
     
     let tabsState = $state<TabsState | null>(null);
+    let isInitialized = $state(false);
 
     $effect.pre(() => {
-        if (!tabsState) {
-            tabsState = createDefaultTabsState(data.templateData ?? "");
+        if (tabsState) return; // Already initialized
+
+        // Initialize tabs state from URL parameters
+        if (data.initialTemplates?.length) {
+            const tabs = data.initialTemplates.map((template: string) => createDefaultTab(template));
+            tabsState = {
+                tabs,
+                activeTabId: tabs[0]?.id ?? ""
+            };
+        } else {
+            tabsState = createDefaultTabsState(data.templateData);
         }
+        isInitialized = true;
     });
 
     function handleEditorStateChange(nextState: EditorSessionState) {
         const activeTab = getActiveTab(tabsState!);
-        if (activeTab) {
-            tabsState = updateTabState(tabsState!, activeTab.id, nextState, nextState.templateEncoded);
+        if (!activeTab) return;
+
+        // Update tab state - URL will be updated by reactive effect
+        const templateResult = getTemplateData(nextState.templateEncoded);
+        if (templateResult.status === "success") {
+            const newTemplateJSON = JSON.stringify(templateResult.templateObject.toJSON());
+            tabsState = updateTabState(tabsState!, activeTab.id, nextState, newTemplateJSON);
         }
     }
+
+    function buildURLParams(state: TabsState): URLSearchParams {
+        const params = new URLSearchParams(browser ? window.location.search : "");
+        
+        if (state.tabs.length === 1) {
+            const result = getTemplateData(state.tabs[0]!.template);
+            if (result.status === "success") {
+                params.set("template", toURLSafeB64(result.templateObject.encodeTemplate()));
+            } else {
+                params.delete("template");
+            }
+            params.delete("templates");
+        } else {
+            const templates = state.tabs
+                .map(tab => {
+                    const result = getTemplateData(tab.template);
+                    return result.status === "success" ? toURLSafeB64(result.templateObject.encodeTemplate()) : "";
+                })
+                .filter(t => t)
+                .join('|');
+            
+            if (templates) {
+                params.set("templates", templates);
+            } else {
+                params.delete("templates");
+            }
+            params.delete("template");
+        }
+
+        return params;
+    }
+
+    function updateURLState() {
+        if (!browser || !tabsState || !isInitialized) return;
+
+        try {
+            const params = buildURLParams(tabsState);
+            const loc = new URL(window.location.href);
+            loc.search = params.toString();
+            replaceState(loc, null);
+        } catch (error) {
+            // Silently ignore if router isn't ready yet
+            console.debug("URL update deferred", error);
+        }
+    }
+
+    // Update URL reactively when tabs state changes
+    $effect(() => {
+        if (tabsState) {
+            updateURLState();
+        }
+    });
 
     function handleCreateTab() {
         tabsState = addTab(tabsState!);
@@ -47,10 +127,10 @@
 <div style="width: 100%; height: 100%; display: flex; flex-direction: column;" bind:offsetWidth={containerWidth} bind:offsetHeight={containerHeight}>
     {#if tabsState}
         <!-- Tabs Bar -->
-        <div style="display: flex; gap: 8px; padding: 8px; background-color: var(--background-secondary, #2a2a2a); border-bottom: 1px solid var(--background-tertiary, #3a3a3a); overflow-x: auto; align-items: center;">
+        <div style="display: flex; gap: 6px; padding: 12px; background-color: var(--background-secondary, #2a2a2a); border-bottom: 1px solid var(--background-tertiary, #3a3a3a); overflow-x: auto; align-items: center; border-radius: 15px 15px 0 0;">
             {#each tabsState.tabs as tab (tab.id)}
                 <div
-                        style="display: flex; align-items: center; gap: 8px; padding: 8px 12px; background-color: {tab.id === tabsState.activeTabId ? 'var(--primary, #0066cc)' : 'var(--background-tertiary, #3a3a3a)'}; color: white; border-radius: 4px; cursor: pointer; white-space: nowrap;"
+                        style="display: flex; align-items: center; gap: 6px; padding: 10px 14px; background-color: {tab.id === tabsState.activeTabId ? 'var(--primary, #0066cc)' : 'var(--background-tertiary, #3a3a3a)'}; color: white; border-radius: 8px; cursor: pointer; white-space: nowrap; min-height: 40px; box-shadow: {tab.id === tabsState.activeTabId ? '0 2px 4px rgba(0,0,0,0.2)' : 'none'}; transition: all 0.15s ease;"
                         onclick={() => handleSwitchTab(tab.id)}
                         onkeydown={(e) => {
                             if (e.key === 'Enter' || e.key === ' ') {
@@ -61,10 +141,27 @@
                         role="button"
                         tabindex="0"
                 >
-                    <span>{tab.name}</span>
+                    <!-- Icon placeholder for consistent height -->
+                    <div style="width: 18px; height: 18px; display: flex; align-items: center; justify-content: center;">
+                        {#if tab.icon}
+                            <img src={tab.icon} alt="" width="18" height="18" style="border-radius: 3px;" />
+                        {:else}
+                            <!-- Invisible placeholder to maintain height -->
+                            <div style="width: 18px; height: 18px;"></div>
+                        {/if}
+                    </div>
+                    
+                    {#if !tab.showOnlyIcon}
+                        <span style="font-weight: {tab.id === tabsState.activeTabId ? '500' : '400'}; opacity: {tab.name ? '1' : '0.7'};">
+                            {tab.name || 'New Tab'}
+                        </span>
+                    {/if}
+                    
                     {#if tabsState.tabs.length > 1}
                         <button
-                                style="padding: 2px 6px; background-color: transparent; color: white; border: none; cursor: pointer; font-size: 12px; line-height: 1; margin-left: 4px;"
+                                style="padding: 2px 6px; background-color: transparent; color: white; border: none; cursor: pointer; font-size: 12px; line-height: 1; margin-left: 4px; opacity: 0.7; border-radius: 3px; transition: opacity 0.15s ease;"
+                                onmouseenter={(e) => e.target.style.opacity = '1'}
+                                onmouseleave={(e) => e.target.style.opacity = '0.7'}
                                 onclick={(e) => {
                                     e.stopPropagation();
                                     handleCloseTab(tab.id);
@@ -77,7 +174,9 @@
                 </div>
             {/each}
             <button
-                    style="padding: 8px 12px; background-color: var(--background-tertiary, #3a3a3a); color: white; border: none; border-radius: 4px; cursor: pointer;"
+                    style="padding: 10px 14px; background-color: var(--background-tertiary, #3a3a3a); color: white; border: none; border-radius: 8px; cursor: pointer; font-size: 14px; font-weight: 500; transition: all 0.15s ease; min-height: 40px;"
+                    onmouseenter={(e) => e.target.style.backgroundColor = 'var(--background-primary, #4a4a4a)'}
+                    onmouseleave={(e) => e.target.style.backgroundColor = 'var(--background-tertiary, #3a3a3a)'}
                     onclick={handleCreateTab}
                     title="Create new tab"
             >
@@ -86,16 +185,18 @@
         </div>
 
         <!-- Editor Container -->
-        <div style="flex: 1; min-height: 0;">
+        <div style="flex: 1; min-height: 0; background-color: var(--background-secondary, #2a2a2a); border-radius: 0 0 15px 15px; overflow: hidden;">
             {#key tabsState.activeTabId}
                 {#if activeTab}
-                    <Editor
-                            template={activeTab.template}
-                            editorState={activeTab.editorState}
-                            onStateChange={handleEditorStateChange}
-                            containerWidth={containerWidth}
-                            containerHeight={containerHeight - 50}
-                    ></Editor>
+                    <div style="height: 100%; border-radius: 0;">
+                        <Editor
+                                template={activeTab.template}
+                                editorState={activeTab.editorState}
+                                onStateChange={handleEditorStateChange}
+                                containerWidth={containerWidth}
+                                containerHeight={containerHeight - 70}
+                        ></Editor>
+                    </div>
                 {/if}
             {/key}
         </div>

--- a/src/routes/editor/+page.svelte
+++ b/src/routes/editor/+page.svelte
@@ -1,16 +1,42 @@
 <script lang="ts">
     import Editor from "$lib/components/editor/Editor.svelte";
     import type { EditorSessionState } from "$lib/components/editor/editor-state";
+    import type { TabsState } from "$lib/components/editor/tabs-state";
+    import { createDefaultTabsState, getActiveTab, addTab, removeTab, switchTab, updateTabState } from "$lib/components/editor/tabs-state";
 
     let {data} = $props();
 
     let containerWidth: number = $state(0);
     let containerHeight: number = $state(0);
-    let editorState: EditorSessionState | null = $state(null);
+    
+    let tabsState = $state<TabsState | null>(null);
+
+    $effect.pre(() => {
+        if (!tabsState) {
+            tabsState = createDefaultTabsState(data.templateData ?? "");
+        }
+    });
 
     function handleEditorStateChange(nextState: EditorSessionState) {
-        editorState = nextState;
+        const activeTab = getActiveTab(tabsState!);
+        if (activeTab) {
+            tabsState = updateTabState(tabsState!, activeTab.id, nextState, nextState.templateEncoded);
+        }
     }
+
+    function handleCreateTab() {
+        tabsState = addTab(tabsState!);
+    }
+
+    function handleSwitchTab(tabId: string) {
+        tabsState = switchTab(tabsState!, tabId);
+    }
+
+    function handleCloseTab(tabId: string) {
+        tabsState = removeTab(tabsState!, tabId);
+    }
+
+    let activeTab = $derived(tabsState ? getActiveTab(tabsState) : null);
 </script>
 
 <svelte:head>
@@ -18,12 +44,61 @@
     <meta name="description" content="Create and share DiamondFire code with each other or for yourself." />
 </svelte:head>
 
-<div style="width: 100%; height: 100%" bind:offsetWidth={containerWidth} bind:offsetHeight={containerHeight}>
-    <Editor
-            template={data.templateData}
-            {editorState}
-            onStateChange={handleEditorStateChange}
-            {containerWidth}
-            {containerHeight}
-    ></Editor>
+<div style="width: 100%; height: 100%; display: flex; flex-direction: column;" bind:offsetWidth={containerWidth} bind:offsetHeight={containerHeight}>
+    {#if tabsState}
+        <!-- Tabs Bar -->
+        <div style="display: flex; gap: 8px; padding: 8px; background-color: var(--background-secondary, #2a2a2a); border-bottom: 1px solid var(--background-tertiary, #3a3a3a); overflow-x: auto; align-items: center;">
+            {#each tabsState.tabs as tab (tab.id)}
+                <div
+                        style="display: flex; align-items: center; gap: 8px; padding: 8px 12px; background-color: {tab.id === tabsState.activeTabId ? 'var(--primary, #0066cc)' : 'var(--background-tertiary, #3a3a3a)'}; color: white; border-radius: 4px; cursor: pointer; white-space: nowrap;"
+                        onclick={() => handleSwitchTab(tab.id)}
+                        onkeydown={(e) => {
+                            if (e.key === 'Enter' || e.key === ' ') {
+                                e.preventDefault();
+                                handleSwitchTab(tab.id);
+                            }
+                        }}
+                        role="button"
+                        tabindex="0"
+                >
+                    <span>{tab.name}</span>
+                    {#if tabsState.tabs.length > 1}
+                        <button
+                                style="padding: 2px 6px; background-color: transparent; color: white; border: none; cursor: pointer; font-size: 12px; line-height: 1; margin-left: 4px;"
+                                onclick={(e) => {
+                                    e.stopPropagation();
+                                    handleCloseTab(tab.id);
+                                }}
+                                title="Close tab"
+                        >
+                            ✕
+                        </button>
+                    {/if}
+                </div>
+            {/each}
+            <button
+                    style="padding: 8px 12px; background-color: var(--background-tertiary, #3a3a3a); color: white; border: none; border-radius: 4px; cursor: pointer;"
+                    onclick={handleCreateTab}
+                    title="Create new tab"
+            >
+                + New Tab
+            </button>
+        </div>
+
+        <!-- Editor Container -->
+        <div style="flex: 1; min-height: 0;">
+            {#key tabsState.activeTabId}
+                {#if activeTab}
+                    <Editor
+                            template={activeTab.template}
+                            editorState={activeTab.editorState}
+                            onStateChange={handleEditorStateChange}
+                            containerWidth={containerWidth}
+                            containerHeight={containerHeight - 50}
+                    ></Editor>
+                {/if}
+            {/key}
+        </div>
+    {/if}
 </div>
+

--- a/src/routes/editor/+page.svelte
+++ b/src/routes/editor/+page.svelte
@@ -1,10 +1,16 @@
 <script lang="ts">
     import Editor from "$lib/components/editor/Editor.svelte";
+    import type { EditorSessionState } from "$lib/components/editor/editor-state";
 
     let {data} = $props();
 
     let containerWidth: number = $state(0);
     let containerHeight: number = $state(0);
+    let editorState: EditorSessionState | null = $state(null);
+
+    function handleEditorStateChange(nextState: EditorSessionState) {
+        editorState = nextState;
+    }
 </script>
 
 <svelte:head>
@@ -13,5 +19,11 @@
 </svelte:head>
 
 <div style="width: 100%; height: 100%" bind:offsetWidth={containerWidth} bind:offsetHeight={containerHeight}>
-    <Editor template={data.templateData} {containerWidth} {containerHeight}></Editor>
+    <Editor
+            template={data.templateData}
+            {editorState}
+            onStateChange={handleEditorStateChange}
+            {containerWidth}
+            {containerHeight}
+    ></Editor>
 </div>

--- a/src/routes/editor/+page.ts
+++ b/src/routes/editor/+page.ts
@@ -1,7 +1,29 @@
-import {fromURLSafeB64} from "$lib/utils";
+import {fromURLSafeB64, toURLSafeB64} from "$lib/utils";
+import { getTemplateData } from "$lib/templatedata";
 
 export function load({ url }) {
-    return {
-        templateData: fromURLSafeB64(new URL(url).searchParams.get("template") ?? "")
+    const templateParam = new URL(url).searchParams.get("template");
+    const templatesParam = new URL(url).searchParams.get("templates");
+
+    if (templatesParam) {
+        // Multiple templates format: templates=template1|template2|template3
+        const templates = templatesParam.split('|').map(t => {
+            const decoded = fromURLSafeB64(t);
+            const result = getTemplateData(decoded);
+            return result.status === "success" ? JSON.stringify(result.templateObject.toJSON()) : "";
+        });
+        return {
+            initialTemplates: templates,
+            templateData: templates[0] || ""
+        };
+    } else {
+        // Single template format: template=xxxx
+        const decoded = templateParam ? fromURLSafeB64(templateParam) : "";
+        const result = getTemplateData(decoded);
+        const templateJSON = result.status === "success" ? JSON.stringify(result.templateObject.toJSON()) : "";
+        return {
+            initialTemplates: templateParam ? [templateJSON] : [],
+            templateData: templateJSON
+        };
     }
 }

--- a/static/shared.css
+++ b/static/shared.css
@@ -32,7 +32,7 @@ body {
     position: relative;
     display: flex;
     flex-direction: column;
-    overflow-y: scroll;
+    overflow-y: hidden;
 }
 
 .tooltip {

--- a/static/shared.css
+++ b/static/shared.css
@@ -58,7 +58,7 @@ body {
 
 .container {
     background: var(--background-secondary);
-    border-radius: 15px;
+    border-radius: 0;
     padding: 20px;
     box-sizing: border-box;
 }

--- a/static/shared.css
+++ b/static/shared.css
@@ -32,7 +32,7 @@ body {
     position: relative;
     display: flex;
     flex-direction: column;
-    overflow-y: hidden;
+    overflow-y: auto;
 }
 
 .tooltip {

--- a/static/theme_charcoal.css
+++ b/static/theme_charcoal.css
@@ -1,0 +1,22 @@
+:root {
+    --background-primary: #1a1a1e;
+    --background-secondary: #242428;
+    --background-tertiary: #2e2e33;
+    --primary: #6b7ae8;
+    --primary-light: #8a9ff0;
+    --primary-dark: #5568d3;
+    --cool-dark: #1a1f3a;
+    --cool: #2d3a6b;
+    --cool-light: #4a5b9d;
+    --cool-black: #0f1117;
+    --white: #e4e6eb;
+    --black: #0a0a0d;
+    --success: #3fb950;
+    --warning: #d29922;
+    --error: #f85149;
+    --info: #44a3f7;
+    --text: #c9cace;
+    --text-primary: #e4e6eb;
+    --text-cool: #b8c5d6;
+    --text-white: #0a0a0d;
+}

--- a/static/themes.json
+++ b/static/themes.json
@@ -1,4 +1,5 @@
 {
+  "charcoal": "Charcoal",
   "light": "Light",
   "dark": "Dark",
   "gray": "Grayscale",


### PR DESCRIPTION
Adds a tab system that allows for multiple templates to exist and some UI improvements.

`editor/+page.svelte` now handles and contains a *tab bar* that allows the user to create, destroy and change the current template to be edited.
The link now supports `?templates=`, which will only be enabled with more than one open tab.

`Editor.svelte` and its children have been refactored to be able to return all the necesary information to the tab manager.

Fixed many `overflow` css properties, and added a new *Charcoal* default theme.